### PR TITLE
95 Delete Draft Datasets

### DIFF
--- a/ckan/src/ckanext-auscope-theme/ckanext/auscope_theme/helpers.py
+++ b/ckan/src/ckanext-auscope-theme/ckanext/auscope_theme/helpers.py
@@ -5,6 +5,10 @@ import ckan.authz as authz
 from datetime import date, datetime
 from zoneinfo import ZoneInfo
 
+from ckan.logic.auth import get_package_object
+from ckan.logic import _prepopulate_context
+from ckan.common import current_user # move up if needed
+
 
 
 def auscope_theme_hello():
@@ -58,6 +62,22 @@ def render_tz_date_from_datetime(dt_str):
     return dt_str
 
 
+def user_can_delete_draft_dataset(package_id):
+    """
+    Check if a user can delete a draft dataset.
+    Admins can delete any draft, but editors/members can only delete their own
+
+    :param str package_id: the ID of the dataset
+    """
+    context = _prepopulate_context(None)
+    package = get_package_object(context, {'id': package_id})
+    user_role = authz.users_role_for_group_or_org(package.owner_org, current_user.name)
+
+    # Editors, admins and the package creator can delete a draft dataset
+    if package.state == 'draft' and (package.creator_user_id == current_user.id or user_role == 'admin'):
+        return True
+
+
 def get_helpers():
     return {
         "auscope_theme_hello": auscope_theme_hello,
@@ -67,4 +87,5 @@ def get_helpers():
         'users_role_in_org': users_role_in_org,
         'current_date': current_date,
         'render_tz_date_from_datetime': render_tz_date_from_datetime,
+        'user_can_delete_draft_dataset': user_can_delete_draft_dataset,
     }

--- a/ckan/src/ckanext-auscope-theme/ckanext/auscope_theme/helpers.py
+++ b/ckan/src/ckanext-auscope-theme/ckanext/auscope_theme/helpers.py
@@ -1,13 +1,11 @@
-from ckan.common import config
+from ckan.common import config, current_user
+from ckan.logic import _prepopulate_context
+from ckan.logic.auth import get_package_object
 from ckan.plugins import toolkit
-import ckan.logic as logic
-import ckan.authz as authz
 from datetime import date, datetime
 from zoneinfo import ZoneInfo
-
-from ckan.logic.auth import get_package_object
-from ckan.logic import _prepopulate_context
-from ckan.common import current_user # move up if needed
+import ckan.logic as logic
+import ckan.authz as authz
 
 
 

--- a/ckan/src/ckanext-auscope-theme/ckanext/auscope_theme/templates/package/new_package_form.html
+++ b/ckan/src/ckanext-auscope-theme/ckanext/auscope_theme/templates/package/new_package_form.html
@@ -1,0 +1,27 @@
+{% extends 'package/snippets/package_form.html' %}
+
+{% block stages %}
+  {% if form_style != 'edit' %}
+    {{ super() }}
+  {% endif %}
+{% endblock %}
+
+{% block save_button_text %}
+  {% if form_style != 'edit' %}
+    {{ super() }}
+  {% else %}
+    {{ h.humanize_entity_type('package', pkg_dict.type, 'update label') or _('Update Dataset') }}
+  {% endif %}
+{% endblock %}
+
+{% block cancel_button %}
+  {% if form_style != 'edit' %}
+    {{ super() }}
+  {% endif %}
+{% endblock %}
+
+{% block delete_button %}
+  {% if (form_style == 'edit' and h.check_access('package_delete', {'id': pkg_dict.id})) or (form_style == 'new' and 'id' in data and  h.user_can_delete_draft_dataset(data.id)) %}
+    {{ super() }}
+  {% endif %}
+{% endblock %}

--- a/ckan/src/ckanext-auscope-theme/ckanext/auscope_theme/templates/package/snippets/package_form.html
+++ b/ckan/src/ckanext-auscope-theme/ckanext/auscope_theme/templates/package/snippets/package_form.html
@@ -1,0 +1,50 @@
+{% import 'macros/form.html' as form %}
+{% set action = g.form_action or '' %}
+
+{# This provides a full page that renders a form for adding a dataset. It can
+then itself be extended to add/remove blocks of functionality. #}
+<form id="dataset-edit" method="post" action="{{ action }}" data-module="basic-form" novalidate>
+  {{ h.csrf_input() }}
+  {% block stages %}
+    {{ h.snippet('package/snippets/stages.html', stages=stage, dataset_type=dataset_type) }}
+  {% endblock %}
+
+  <input type="hidden" name="_ckan_phase" value="dataset_new_1" />
+  {# pkg_name used in 3 stage edit #}
+  <input type="hidden" name="pkg_name" value="{{ data.id }}" />
+  {% block errors %}{{ form.errors(error_summary) }}{% endblock %}
+
+  {% block basic_fields %}
+    {% snippet 'package/snippets/package_basic_fields.html', data=data, errors=errors %}
+  {% endblock %}
+
+  {% block metadata_fields %}
+    {% snippet 'package/snippets/package_metadata_fields.html', data=data, errors=errors %}
+  {% endblock %}
+
+  {% block form_actions %}
+    {{ form.required_message() }}
+
+    <div class="form-actions">
+      {% block disclaimer %}
+        <p class="action-info small">
+          {%- trans -%}
+          The <i>data license</i> you select above only applies to the contents
+          of any resource files that you add to this dataset. By submitting
+          this form, you agree to release the <i>metadata</i> values that you
+          enter into the form under the
+          <a href="http://opendatacommons.org/licenses/odbl/1-0/">Open Database License</a>.
+          {%- endtrans -%}
+        </p>
+      {% endblock %}
+      {% block delete_button %}
+        {% if (form_style == 'edit' and h.check_access('package_delete', {'id': pkg_dict.id})) or (form_style == 'new' and 'id' in data and h.user_can_delete_draft_dataset(data.id)) %}
+          <a class="btn btn-danger pull-left" href="{% url_for dataset_type ~ '.delete', id=data.id %}" data-module="confirm-action" data-module-content="{{ h.humanize_entity_type('package', dataset_type, 'delete confirmation') or _('Are you sure you want to delete this dataset?') }}">{% block delete_button_text %}{{ _('Delete') }}{% endblock %}</a>
+	{% endif %}
+      {% endblock %}
+      {% block save_button %}
+        <button class="btn btn-primary" type="submit" name="save">{% block save_button_text %}{{ _('Next: Add Data') }}{% endblock %}</button>
+      {% endblock %}
+    </div>
+  {% endblock %}
+</form>


### PR DESCRIPTION
Allow users to delete their own draft datasets. Admins can delete all draft datasets.