### PR TITLE
AuScopeDataRepo - Hard Coded Org ID in Validator

### DIFF
--- a/ckan/src/ckanext-auscope-theme/ckanext/auscope_theme/templates/scheming/form_snippets/org_visibility.html
+++ b/ckan/src/ckanext-auscope-theme/ckanext/auscope_theme/templates/scheming/form_snippets/org_visibility.html
@@ -22,7 +22,7 @@
 
     <select id="field-organizations" name="owner_org" style="display:none;">
 	{# Need to get this from config  #}
-        <option value="12345678-1234-1234-1234-123456789012"></option>
+        <option value="auscope"></option>
     </select>
 
     {% block package_metadata_fields_visibility %}


### PR DESCRIPTION
Removed hard-coded org ID from org_visibility validator