### PR TITLE
AuScope Data Repository Fix Admin Email

### DIFF
--- a/ckan/src/ckanext-auscope-theme/ckanext/auscope_theme/logic/schema.py
+++ b/ckan/src/ckanext-auscope-theme/ckanext/auscope_theme/logic/schema.py
@@ -5,6 +5,7 @@ from ckan.common import config
 from ckan.lib.base import render
 import ckan.lib.mailer as mailer
 from datetime import datetime
+import os
 
 
 
@@ -162,7 +163,7 @@ def send_admin_dataset_notification(context, pkg_dict):
     dataset_title = pkg_dict['title']
     subject = 'AuScope Data Repository - Dataset Submitted "{dataset_title}"'.format(dataset_title=dataset_title)
     recipient_name = 'AuScope Data Repository admin'
-    recipient_email = config.get('ckan_sysadmin_email')
+    recipient_email = os.environ.get('CKAN_SYSADMIN_EMAIL')
     mailer.mail_recipient(recipient_name, recipient_email, subject, body)
 
 


### PR DESCRIPTION
Use environment variable instead of CKAN setting to get admin email for submission email receipt